### PR TITLE
Change to make osutils work cross-platform.

### DIFF
--- a/brennivin/osutils.py
+++ b/brennivin/osutils.py
@@ -160,7 +160,6 @@ def path_components(path):
     while True:
         newpath, tail = ntpath.split(path)
         if newpath == path:
-            assert not tail
             if path:
                 parts.append(path)
             break

--- a/brennivin/osutils.py
+++ b/brennivin/osutils.py
@@ -10,6 +10,7 @@ import binascii as _binascii
 import contextlib as _contextlib
 import errno as _errno
 import fnmatch as _fnmatch
+import ntpath
 import os as _os
 import shutil as _shutil
 import stat as _stat
@@ -153,11 +154,20 @@ def mktemp(*args, **kwargs):
 
 def path_components(path):
     """Return list of a path's components."""
-    folders = path.replace(altsep, _os.sep).split(_os.sep)
-    result = [f for f in folders if f]
-    if _os.name != 'nt' and path[0] == '/':
-        result.insert(0, '/')
-    return result
+    # Thanks to John Machin @ http://stackoverflow.com/a/4580931/884080 and
+    # Moe @ http://stackoverflow.com/a/182417/884080
+    parts = []
+    while True:
+        newpath, tail = ntpath.split(path)
+        if newpath == path:
+            assert not tail
+            if path:
+                parts.append(path)
+            break
+        parts.append(tail)
+        path = newpath
+    parts.reverse()
+    return parts
 
 
 def purename(filename):

--- a/tests/test_osutils.py
+++ b/tests/test_osutils.py
@@ -237,9 +237,11 @@ class MakeDirsTests(unittest.TestCase):
 
 
 class TestPathComponents(unittest.TestCase):
+    msg = "Bad path componentization on '%s'. Expected %s, got %s"
+
     def assertComponentsEqual(self, path, ideal):
         result = osutils.path_components(path)
-        self.assertEqual(result, ideal)
+        self.assertEqual(result, ideal, self.msg % (path, ideal, result))
 
     def testValidPaths(self):
         self.assertComponentsEqual(join(ROOT, 'foo', 'bar.baz'),
@@ -249,13 +251,43 @@ class TestPathComponents(unittest.TestCase):
 
     def testForwardSlashes(self):
         self.assertComponentsEqual('c:/foo/bar.baz',
-                                   ['c:', 'foo', 'bar.baz'])
+                                   ['c:/', 'foo', 'bar.baz'])
         self.assertComponentsEqual('foo/bar.baz',
                                    ['foo', 'bar.baz'])
 
     def testRespaths(self):
         self.assertComponentsEqual('res:/foo/bar.baz',
                                    ['res:', 'foo', 'bar.baz'])
+
+    def testVariousPaths(self):
+        d = {'': [],
+             'foo': ['foo'],
+             'foo/': ['foo', ''],
+             'foo\\': ['foo', ''],
+             '/foo': ['/', 'foo'],
+             '\\foo': ['\\', 'foo'],
+             'foo/bar': ['foo', 'bar'],
+             '/': ['/'],
+             'c:': ['c:'],
+             'c:/': ['c:/'],
+
+             # Windows is weird, here is a valid *relative* path
+             # to the current working directory on drive `c`...
+             'c:foo': ['c:', 'foo'],
+
+             # ...but here is an *absolute* path on drive `c`
+             'c:/foo': ['c:/', 'foo'],
+
+             'c:/users/john/foo.txt': ['c:/', 'users', 'john', 'foo.txt'],
+             'c:/users/mary major/f': ['c:/', 'users', 'mary major', 'f'],
+             'c:\\users\\mary major\\f': ['c:\\', 'users', 'mary major', 'f'],
+             '/users/john/foo.txt': ['/', 'users', 'john', 'foo.txt'],
+             'foo/bar/baz/loop': ['foo', 'bar', 'baz', 'loop'],
+             'foo/bar/baz/': ['foo', 'bar', 'baz', '']}
+
+        for path, ideal in d.items():
+            result = osutils.path_components(path)
+            self.assertEqual(result, ideal, self.msg % (path, ideal, result))
 
 
 class PurenameTests(unittest.TestCase):


### PR DESCRIPTION
Previously some paths were not handled correctly under Windows. It seems ntpath supports all the paths I can throw at it, and still work under both Linux and Windows.
