### PR TITLE
Making Traceback2Tests work under Windows

### DIFF
--- a/tests/test_traceback2.py
+++ b/tests/test_traceback2.py
@@ -29,7 +29,7 @@ class Traceback2Tests(unittest.TestCase):
             self.assertEqual(lines[0], 'Traceback (most recent call last):')
             self.assertRegexpMatches(lines[1], '  File ".*test_traceback2.py", line \d\d, in test_print')
             self.assertEqual(lines[2], '    raise SystemError()')
-            self.assertRegexpMatches(lines[3], '                 out = <.*String\w?O object at 0x([0-9]|[a-z])*>')
+            self.assertRegexpMatches(lines[3], '                 out = <.*String\w?O object at 0x[a-zA-Z0-9]+>')
             self.assertEqual(lines[4], '                self = <tests.test_traceback2.Traceback2Tests testMethod=test_print>')
             self.assertEqual(lines[-1], 'SystemError')
         except AssertionError:  # pragma: no cover


### PR DESCRIPTION
 The previous regex was not capturing uppercased addresses.
